### PR TITLE
cloud init - firstboot.sh userscript for illumos/OpenIndiana

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1691,6 +1691,14 @@ fn run_illumos(log: &Logger, smbios_raw_string: &str) -> Result<()> {
         }
     }
 
+    /*
+     * Get a user-provided first boot script from the archive, if provided:
+     */
+    let script = format!("{}/firstboot.sh", UNPACKDIR);
+    if let Some(script) = read_file(&script)? {
+        phase_userscript(log, &script)?;
+    }
+
     write_lines(log, STAMP, &[ds.uuid])?;
 
     Ok(())

--- a/src/userdata/cloudconfig.rs
+++ b/src/userdata/cloudconfig.rs
@@ -68,7 +68,7 @@ pub struct CloudConfig {
     #[serde(rename = "ca-certs")]
     pub ca_certs: Option<CaCertsData>,
     pub bootcmd: Option<Multiformat>,
-    pub runcms: Option<Multiformat>,
+    pub runcmd: Option<Multiformat>,
     pub final_message: Option<String>,
     pub packages: Option<Multiformat>,
     pub package_update: Option<bool>,


### PR DESCRIPTION
Contains 2 changes:
0f5d14a added support for firstboot.sh userscript for illumos/OpenIndiana
e3dc7aa fixed typo in cloudconfig.rs: runcmd (was: runcms)
